### PR TITLE
Remove explicit dependency on gems in stdlib

### DIFF
--- a/stamina-gui.gemspec
+++ b/stamina-gui.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |s|
   s.add_dependency("stamina-core",      "= #{Stamina::VERSION}")
   s.add_dependency("stamina-induction", "= #{Stamina::VERSION}")
   s.add_dependency("sinatra", "~> 1.3")
-  s.add_dependency("json",    "~> 1.6")
 end

--- a/stamina.noespec
+++ b/stamina.noespec
@@ -49,7 +49,6 @@ variables:
     - {name: rspec,     version: "~> 2.8",    groups: [development]}
     - {name: wlang,     version: "~> 0.10.2", groups: [development]}
     - {name: gnuplot,   version: "~> 2.3.6",  groups: [development]}
-    - {name: json,      version: "~> 1.6",    groups: [development]}
   rake_tasks:
     unit_test:
       libs: [lib, test/unit]


### PR DESCRIPTION
`json` is included in the Ruby standard library for all supported versions of Ruby.